### PR TITLE
Add Continuous Integration and Fix Build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,34 @@
+name: CMake
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # recursively checkout all submodules
+        submodules: 'recursive'
+
+    - name: install dependencies
+      run: |
+        APTGETYES=1 make -j1 installUbuntuAll
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.4)
 
 project(RaiPython)
 
+find_package(PkgConfig)
+pkg_check_modules(BULLET bullet REQUIRED)
+
 add_subdirectory(pybind11)
 
 add_compile_options(


### PR DESCRIPTION
One of our MS students had trouble getting this repo to work. Ultimately, this was just because bullet was not found automatically by CMake. This PR adds (in two commits) two features:

1. Bullet is now found automatically (using PkgConfig)
2. Github Actions are employed as continuous integration (CI). On each push (and pull request) the code is built. The maintainer will receive an email if the build is broken. In the future, it would be possible to extend the CI to also run all the Jupyter notebooks to verify that the API didn't change.

The github actions were verified by committing the bullet fix second. The original run failed with the same error the student was facing. The second commit (with the fix for bullet) lets CI pass, see https://github.com/whoenig/rai-python/actions.